### PR TITLE
Update swipe.js

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -74,6 +74,7 @@
       // set continuous to false if only one slide
       if (slides.length < 2) {
         options.continuous = false;
+        index = 0;
       }
 
       //special case if two slides


### PR DESCRIPTION
if only have one pic and startSlide's value is greater than 0,then the translate function will make the pic's style's transform value to - pic width and the pic will show none
while slides.length < 2 set index (startSlide's value) to 0.